### PR TITLE
prepare 1.0.1 release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ package-lock.json
 dist
 .idea
 .vscode/
+docs/build/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to the LaunchDarkly Electron SDK will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org).
 
+## [1.0.1] - 2019-03-25
+### Fixed:
+- Improved TypeScript documentation comments throughout. This is the only change in the `ldclient-electron` package. However, the following fixes were made in the 2.9.5 release of `ldclient-js-common` (which will be picked up automatically by `ldclient-electron` even if you are using the previous release, since its dependency version is "^2.9.0"):
+- The user attributes `secondary` and `privateAttributeNames` were not included in the TypeScript declarations and therefore could not be used from TypeScript code.
+- Corrected the TypeScript declaration for the `identify` method to indicate that its asynchronous result type is `LDFlagSet`, not `void`.
+- If the SDK received streaming updates out of order (rare, but possible) such that it received "flag X was deleted" prior to "flag X was created", an uncaught exception would be logged (but would not otherwise affect anything).
+
 ## [1.0.0] - 2019-02-01
 First full release.
 

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,30 @@
+
+# The TypeDoc build for ldclient-electron is more complicated than for ldclient-node because ldclient-electron
+# takes some of its types from ldclient-js-common. TypeDoc unfortunately does not understand the directive
+# "export * from 'ldclient-js-common'" - so, by default, even though it does see the common types (like
+# LDUser), it will not include them in the output.
+#
+# The current solution is to run TypeDoc on a hacked-together file that puts all of the types directly
+# into one package. The sed commands below create this temporary declaration file by taking the types file
+# from ldclient-electron and replacing the section in between DOCBUILD-START-REPLACE and DOCBUILD-END-REPLACE
+# with the section of the types file from ldclient-js-common in between DOCBUILD-START-EXCERPT and
+# DOCBUILD-END-EXCERPT. We then run TypeDoc from the docs directory, which contains its own tsconfig.json
+# that points to the temporarily file instead of the original files.
+#
+# We also do a little search-and-replace trickery to change linked references to "LDClient.someMethod" to
+# "LDElectronMainClient.someMethod or LDElectronRendererClient.someMethod".
+# 
+
+.PHONY: html prepare
+
+html: prepare
+	../node_modules/.bin/typedoc --options typedoc.js
+
+prepare:
+	rm -rf build
+	mkdir build
+	sed -n '/DOCBUILD-START-EXCERPT/,/DOCBUILD-END-EXCERPT/p' ../node_modules/ldclient-js-common/typings.d.ts | \
+		sed -e 's/\[\[LDClient\.\([^]]*\)\]\]/[[LDElectronMainClient.\1]] or [[LDElectronRendererClient.\1]]/g' \
+		>build/common-excerpt
+	sed -e '/DOCBUILD-END-REPLACE/r build/common-excerpt' ../typings.d.ts | \
+		sed -e '/DOCBUILD-START-REPLACE/,/DOCBUILD-END-REPLACE/d' >build/typings.d.ts

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -6,10 +6,9 @@
 #
 # The current solution is to run TypeDoc on a hacked-together file that puts all of the types directly
 # into one package. The sed commands below create this temporary declaration file by taking the types file
-# from ldclient-electron and replacing the section in between DOCBUILD-START-REPLACE and DOCBUILD-END-REPLACE
-# with the section of the types file from ldclient-js-common in between DOCBUILD-START-EXCERPT and
-# DOCBUILD-END-EXCERPT. We then run TypeDoc from the docs directory, which contains its own tsconfig.json
-# that points to the temporarily file instead of the original files.
+# from ldclient-js and replacing the ldclient-js-common imports with the actual contents of the
+# ldclient-js-common module. We then run TypeDoc from the docs directory, which contains its own
+# tsconfig.json that points to the temporarily file instead of the original files.
 #
 # We also do a little search-and-replace trickery to change linked references to "LDClient.someMethod" to
 # "LDElectronMainClient.someMethod or LDElectronRendererClient.someMethod".
@@ -23,8 +22,12 @@ html: prepare
 prepare:
 	rm -rf build
 	mkdir build
-	sed -n '/DOCBUILD-START-EXCERPT/,/DOCBUILD-END-EXCERPT/p' ../node_modules/ldclient-js-common/typings.d.ts | \
+	@# Extract the whole module declaration from ldclient-js-common, then remove the first and last lines;
+	@# also search and replace client class name as described above
+	sed -n '/^declare module/,/^}/p' ../node_modules/ldclient-js-common/typings.d.ts | \
+		sed '1d;$$d' | \
 		sed -e 's/\[\[LDClient\.\([^]]*\)\]\]/[[LDElectronMainClient.\1]] or [[LDElectronRendererClient.\1]]/g' \
 		>build/common-excerpt
+	@# Replace the block from DOCBUILD-START-REPLACE to DOCBUILD-END-REPLACE with that excerpt
 	sed -e '/DOCBUILD-END-REPLACE/r build/common-excerpt' ../typings.d.ts | \
 		sed -e '/DOCBUILD-START-REPLACE/,/DOCBUILD-END-REPLACE/d' >build/typings.d.ts

--- a/docs/tsconfig.json
+++ b/docs/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "strict": true,
+    "lib": [
+      "es6"
+    ]
+  },
+  "files": [
+    "build/typings.d.ts"
+  ]
+}

--- a/docs/typedoc.js
+++ b/docs/typedoc.js
@@ -1,0 +1,13 @@
+
+// Note that the format of this file is barely documented on the TypeDoc site. In general,
+// the properties are equivalent to the command-line options described here:
+// https://typedoc.org/api/
+
+module.exports = {
+  out: './build/html',
+  name: 'LaunchDarkly Electron SDK',
+  readme: 'none',                // don't add a home page with a copy of README.md
+  mode: 'file',                  // don't treat "typings.d.ts" itself as a parent module
+  includeDeclarations: true,     // allows it to process a .d.ts file instead of actual TS code
+  entryPoint: '"ldclient-electron"'  // note extra quotes - workaround for a TypeDoc bug
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ldclient-electron",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "LaunchDarkly SDK for Electron",
   "author": "LaunchDarkly <team@launchdarkly.com>",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "semver": "5.5.0",
     "semver-compare": "1.0.0",
     "sinon": "4.5.0",
+    "typedoc": "0.14.2",
     "typescript": "3.0.1"
   },
   "dependencies": {


### PR DESCRIPTION
## [1.0.1] - 2019-03-25
### Fixed:
- Improved TypeScript documentation comments throughout. This is the only change in the `ldclient-electron` package. However, the following fixes were made in the 2.9.5 release of `ldclient-js-common` (which will be picked up automatically by `ldclient-electron` even if you are using the previous release, since its dependency version is "^2.9.0"):
- The user attributes `secondary` and `privateAttributeNames` were not included in the TypeScript declarations and therefore could not be used from TypeScript code.
- Corrected the TypeScript declaration for the `identify` method to indicate that its asynchronous result type is `LDFlagSet`, not `void`.
- If the SDK received streaming updates out of order (rare, but possible) such that it received "flag X was deleted" prior to "flag X was created", an uncaught exception would be logged (but would not otherwise affect anything).
