### PR TITLE
Updates outdated Docs site URLs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to the LaunchDarkly Client-Side Electron SDK
 
-LaunchDarkly has published an [SDK contributor's guide](https://docs.launchdarkly.com/docs/sdk-contributors-guide) that provides a detailed explanation of how our SDKs work. See below for additional information on how to contribute to this SDK.
+LaunchDarkly has published an [SDK contributor's guide](https://docs.launchdarkly.com/sdk/concepts/contributors-guide) that provides a detailed explanation of how our SDKs work. See below for additional information on how to contribute to this SDK.
 
 ## Submitting bug reports and feature requests
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## LaunchDarkly overview
 
-[LaunchDarkly](https://www.launchdarkly.com) is a feature management platform that serves over 100 billion feature flags daily to help teams build better software, faster. [Get started](https://docs.launchdarkly.com/docs/getting-started) using LaunchDarkly today!
+[LaunchDarkly](https://www.launchdarkly.com) is a feature management platform that serves over 100 billion feature flags daily to help teams build better software, faster. [Get started](https://docs.launchdarkly.com/home/getting-started) using LaunchDarkly today!
 
 [![Twitter Follow](https://img.shields.io/twitter/follow/launchdarkly.svg?style=social&label=Follow&maxAge=2592000)](https://twitter.com/intent/follow?screen_name=launchdarkly)
 
@@ -14,9 +14,9 @@ This version of the LaunchDarkly SDK is tested against Electron 2.x through 9.x.
 
 ## Getting started
 
-Refer to the [SDK documentation](https://docs.launchdarkly.com/docs/electron-sdk-reference) for instructions on getting started with using the SDK.
+Refer to the [SDK documentation](https://docs.launchdarkly.com/sdk/client-side/electron) for instructions on getting started with using the SDK.
 
-Please note that the Electron SDK, like the [browser Javascript SDK](https://docs.launchdarkly.com/docs/js-sdk-reference), has two special requirements in terms of your LaunchDarkly environment. First, in terms of the credentials for your environment that appear on your [Account Settings](https://app.launchdarkly.com/settings/projects) dashboard, the JavaScript SDK uses the "Client-side ID" (also called the environment ID)-- not the "SDK key" or the "Mobile key". Second, for any feature flag that you will be using in Electron, you must check the "Make this flag available to client-side SDKs" box on that flag's Settings page.
+Please note that the Electron SDK, like the [browser Javascript SDK](https://docs.launchdarkly.com/sdk/client-side/javascript), has two special requirements in terms of your LaunchDarkly environment. First, in terms of the credentials for your environment that appear on your [Account Settings](https://app.launchdarkly.com/settings/projects) dashboard, the JavaScript SDK uses the "Client-side ID" (also called the environment ID)-- not the "SDK key" or the "Mobile key". Second, for any feature flag that you will be using in Electron, you must check the "Make this flag available to client-side SDKs" box on that flag's Settings page.
 
 ## Learn more
 
@@ -39,7 +39,7 @@ We encourage pull requests and other contributions from the community. Check out
     * Gradually roll out a feature to an increasing percentage of users, and track the effect that the feature has on key metrics (for instance, how likely is a user to complete a purchase if they have feature A versus feature B?).
     * Turn off a feature that you realize is causing performance problems in production, without needing to re-deploy, or even restart the application with a changed configuration file.
     * Grant access to certain features based on user attributes, like payment plan (eg: users on the ‘gold’ plan get access to more features than users in the ‘silver’ plan). Disable parts of your application to facilitate maintenance, without taking everything offline.
-* LaunchDarkly provides feature flag SDKs for a wide variety of languages and technologies. Check out [our documentation](https://docs.launchdarkly.com/docs) for a complete list.
+* LaunchDarkly provides feature flag SDKs for a wide variety of languages and technologies. Check out [our documentation](https://docs.launchdarkly.com/sdk) for a complete list.
 * Explore LaunchDarkly
     * [launchdarkly.com](https://www.launchdarkly.com/ "LaunchDarkly Main Website") for more information
     * [docs.launchdarkly.com](https://docs.launchdarkly.com/  "LaunchDarkly Documentation") for our documentation and SDK reference guides

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -5,7 +5,7 @@
  * an instance of [[LDElectronMainClient]]-- and, optionally, call [[initializeInRenderer]] in a
  * renderer process to obtain a corresponding instance of [[LDElectronRendererClient]].
  *
- * For more information, see the [SDK reference guide](http://docs.launchdarkly.com/docs/electron-sdk-reference).
+ * For more information, see the [SDK reference guide](https://docs.launchdarkly.com/sdk/client-side/electron).
  */
 declare module 'launchdarkly-electron-client-sdk' {
 
@@ -67,7 +67,7 @@ declare module 'launchdarkly-electron-client-sdk' {
    *
    * Applications should configure the client at startup time with [[initializeInMain]], and reuse the same instance.
    *
-   * For more information, see the [SDK Reference Guide](http://docs.launchdarkly.com/docs/electron-sdk-reference).
+   * For more information, see the [SDK Reference Guide](https://docs.launchdarkly.com/sdk/client-side/electron).
    */
   export interface LDElectronMainClient extends LDClientBase {
     /**
@@ -84,7 +84,7 @@ declare module 'launchdarkly-electron-client-sdk' {
      * use [[initializeInRenderer]] to create a client that automatically synchronizes itself with
      * the main process client. However, this method is still provided for compatibility in case
      * you are adapting code that used this mechanism with one of the server-side SDKs.
-     * 
+     *
      * @returns the state object
      */
     allFlagsState(): LDFlagsState;
@@ -94,9 +94,9 @@ declare module 'launchdarkly-electron-client-sdk' {
    * The LaunchDarkly SDK client object for use in an Electron renderer process.
    *
    * Applications should configure the client at page load time with [[initializeInRenderer]]. It is basically a
-   * proxy for the client instance in the main process, and is automatically kept in sync with the main client's state. 
+   * proxy for the client instance in the main process, and is automatically kept in sync with the main client's state.
    *
-   * For more information, see the [SDK Reference Guide](http://docs.launchdarkly.com/docs/electron-sdk-reference).
+   * For more information, see the [SDK Reference Guide](https://docs.launchdarkly.com/sdk/client-side/electron).
    */
   export interface LDElectronRendererClient extends LDClientBase {
   }
@@ -130,7 +130,7 @@ declare module 'launchdarkly-electron-client-sdk' {
      *   The flag key.
      */
     getFlagReason(key: string): LDEvaluationReason;
-    
+
     /**
      * Returns a map of feature flag keys to values. If a flag would have evaluated to the
      * default value, its value will be null.
@@ -205,7 +205,7 @@ declare module 'launchdarkly-electron-client-sdk' {
      *
      * Note that you can also use event listeners ([[on]]) for the same purpose: the event `"ready"`
      * indicates success, and `"failed"` indicates failure.
-     * 
+     *
      * @returns
      *   A Promise that will be resolved if the client initializes successfully, or rejected if it
      *   fails. If successful, the result is the same client object.
@@ -242,7 +242,7 @@ declare module 'launchdarkly-electron-client-sdk' {
      * The `reason` property of the result will also be included in analytics events, if you are
      * capturing detailed event data for this flag.
      *
-     * For more information, see the [SDK reference guide](https://docs.launchdarkly.com/docs/evaluation-reasons).
+     * For more information, see the [SDK reference guide](https://docs.launchdarkly.com/sdk/concepts/evaluation-reasons).
      *
      * @param key
      *   The unique key of the feature flag.
@@ -354,16 +354,16 @@ declare module 'launchdarkly-electron-client-sdk' {
     track(key: string, user: LDUser, data?: any): void;
 
     /**
-     * Associates two users for analytics purposes. 
-     * 
-     * This can be helpful in the situation where a person is represented by multiple 
-     * LaunchDarkly users. This may happen, for example, when a person initially logs into 
+     * Associates two users for analytics purposes.
+     *
+     * This can be helpful in the situation where a person is represented by multiple
+     * LaunchDarkly users. This may happen, for example, when a person initially logs into
      * an application-- the person might be represented by an anonymous user prior to logging
      * in and a different user after logging in, as denoted by a different user key.
-     * 
-     * @param user 
+     *
+     * @param user
      *   The newly identified user.
-     * @param previousUser 
+     * @param previousUser
      *   The previously identified user.
      */
     alias(user: LDUser, previousUser: LDUser): void;


### PR DESCRIPTION
**Requirements**

- [ n/a ] I have added test coverage for new or changed functionality
- [ X ] I have followed the repository's [pull request submission guidelines](../blob/master/CONTRIBUTING.md#submitting-pull-requests)
- [ n/a ] I have validated my changes against all supported platform versions

**Related issues**

N/A

**Describe the solution you've provided**

Updated old URLs linking to the old docs site to current URLs for the current docs site.

**Describe alternatives you've considered**

N/A

**Additional context**

Some docs site URLs changed in 2020 when we changed hosting platforms and there have been IA changes since.