### PR TITLE
Add close stale workflow to public repo

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,10 @@
+name: 'Close stale issues and PRs'
+on:
+  workflow_dispatch:
+  schedule:
+    # Happen once per day at 1:30 AM
+    - cron: '30 1 * * *'
+
+jobs:
+  sdk-close-stale:
+    uses: launchdarkly/gh-actions/.github/workflows/sdk-stale.yml@main


### PR DESCRIPTION
This helps remind requesters when we are explicitly setting the label to `Waiting for Feedback`, which does not affect other issues.
