### PR TITLE
Clarify that "goals" are the same as "metrics"

### DIFF
--- a/src/rendererClient.js
+++ b/src/rendererClient.js
@@ -16,7 +16,7 @@ function initializeInRenderer(optionalEnv, options = {}) {
   config = Object.assign({}, config, {
     stateProvider: interprocessSync.createStateProviderForRendererClient(env, initialState),
     streaming: false, // don't want the renderer client to open a stream if someone subscribes to change events
-    fetchGoals: false, // click/pageview goals aren't supported in Electron
+    fetchGoals: false, // click/pageview metrics aren't supported in Electron
     eventUrlTransformer: makeEventUrlTransformer(),
   });
   return browserClient.initialize(env, null, config);

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -340,12 +340,12 @@ declare module 'launchdarkly-electron-client-sdk' {
     /**
      * Tracks that a user performed an event.
      *
-     * LaunchDarkly automatically tracks pageviews and clicks that are specified in the Goals
-     * section of the dashboard. This can be used to track custom goals or other events that do
-     * not currently have goals.
+     * LaunchDarkly automatically tracks pageviews and clicks that are specified in the Metrics
+     * section of the dashboard. This can be used to track custom metrics (goals) or other events that do
+     * not currently have metrics.
      *
      * @param key
-     *   The name of the event, which may correspond to a goal in A/B tests.
+     *   The name of the event, which may correspond to a metric in experiments.
      * @param user
      *   The user to track.
      * @param data


### PR DESCRIPTION
"Goals" are now called "metrics."

This PR is a copy of #44 in the private repo.

Story details: https://app.shortcut.com/launchdarkly/story/213100