### PR TITLE
Add useNetModule to newHttpRequest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the LaunchDarkly Electron SDK will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org).
 
+## [Unreleased]
+### Added:
+- Added the `useNetModule` option for sending polling, analytics event, and diagnostic requests through Electron's `net` module. Custom `tlsParams` do not apply to this transport.
+
 ## [1.7.0] - 2022-10-21
 ### Changed:
 - Updated `launchdarkly-js-sdk-common` to version `3.8.3`.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ Refer to the [SDK documentation](https://docs.launchdarkly.com/sdk/client-side/e
 
 Please note that the Electron SDK, like the [browser Javascript SDK](https://docs.launchdarkly.com/sdk/client-side/javascript), has two special requirements in terms of your LaunchDarkly environment. First, in terms of the credentials for your environment that appear on your [Account Settings](https://app.launchdarkly.com/settings/projects) dashboard, the JavaScript SDK uses the "Client-side ID" (also called the environment ID)-- not the "SDK key" or the "Mobile key". Second, for any feature flag that you will be using in Electron, you must check the "Make this flag available to client-side SDKs" box on that flag's Settings page.
 
+## Using Electron's net module
+
+Set `useNetModule` to `true` in the options passed to `initializeInMain` to send polling, analytics event, and diagnostic requests through Electron's [`net` module](https://www.electronjs.org/docs/latest/api/net). This uses Chromium's networking stack and system proxy configuration. Streaming connections continue to use the SDK's EventSource transport. Since Electron only makes the `net` API available after the app is ready, call `initializeInMain` after the app's `ready` event when enabling this option.
+
+Electron handles TLS configuration for `net` requests. The SDK does not apply `tlsParams` such as a custom `ca`, `cert`, or `rejectUnauthorized` value when `useNetModule` is enabled, and logs a warning if both options are set. Leave `useNetModule` unset or set it to `false` when the SDK must use custom Node HTTPS configuration.
+
 ## Learn more
 
 Read our [documentation](https://docs.launchdarkly.com) for in-depth instructions on configuring and using LaunchDarkly. You can also head straight to the [complete reference guide for this SDK](https://docs.launchdarkly.com/docs/electron-sdk-reference). Additionally, the authoritative full description of all properties, types, and methods is the [online TypeScript documentation](https://launchdarkly.github.io/electron-client-sdk/). If you are not using TypeScript, then the types are only for your information and are not enforced, although the properties and methods are still the same as described in the documentation.

--- a/src/__tests__/LDClient-useNetModule-test.js
+++ b/src/__tests__/LDClient-useNetModule-test.js
@@ -1,0 +1,81 @@
+import * as LDClient from '../index';
+import * as packageJson from '../../package.json';
+
+import { TestHttpHandlers, TestHttpServer, withCloseable } from 'launchdarkly-js-test-helpers';
+
+describe('LDClient', () => {
+  const envName = 'UNKNOWN_ENVIRONMENT_ID';
+  const user = { key: 'user' };
+
+  it('should exist', () => {
+    expect(LDClient).toBeDefined();
+  });
+
+  it('should report correct version', () => {
+    expect(LDClient.version).toEqual(packageJson.version);
+  });
+
+  describe('initialization', () => {
+    it('should initialize successfully', async () => {
+      await withCloseable(TestHttpServer.start, async server => {
+        const data = { flag: { value: 3 } };
+        server.byDefault(TestHttpHandlers.respondJson(data));
+
+        const client = LDClient.initializeInMain(envName, user, {
+          baseUrl: server.url,
+          sendEvents: false,
+          useNetModule: true,
+        });
+        await withCloseable(client, async () => {
+          await client.waitForInitialization();
+
+          expect(client.variation('flag')).toEqual(3);
+        });
+      });
+    });
+
+    it('sends correct User-Agent in request', async () => {
+      await withCloseable(TestHttpServer.start, async server => {
+        const data = { flag: { value: 3 } };
+        server.byDefault(TestHttpHandlers.respondJson(data));
+
+        const client = LDClient.initializeInMain(envName, user, {
+          baseUrl: server.url,
+          sendEvents: false,
+          useNetModule: true,
+        });
+        await withCloseable(client, async () => {
+          await client.waitForInitialization();
+
+          expect(server.requests.length()).toEqual(1);
+          const req = await server.nextRequest();
+          expect(req.headers['x-launchdarkly-user-agent']).toMatch(/^ElectronClient\/1\./);
+        });
+      });
+    });
+  });
+
+  describe('track()', () => {
+    it('should not warn when tracking an arbitrary custom event', async () => {
+      const logger = {
+        debug: jest.fn(),
+        info: jest.fn(),
+        warn: jest.fn(),
+        error: jest.fn(),
+      };
+      const client = LDClient.initializeInMain(envName, user, {
+        bootstrap: {},
+        sendEvents: false,
+        logger: logger,
+        useNetModule: true,
+      });
+      await withCloseable(client, async () => {
+        await client.waitForInitialization();
+
+        client.track('whatever');
+        expect(logger.warn).not.toHaveBeenCalled();
+        expect(logger.error).not.toHaveBeenCalled();
+      });
+    });
+  });
+});

--- a/src/__tests__/LDClient-useNetModule-test.js
+++ b/src/__tests__/LDClient-useNetModule-test.js
@@ -62,7 +62,7 @@ describe('LDClient', () => {
   });
 
   describe('track()', () => {
-    it("sends events through Electron's net module", async () => {
+    it('sends events when useNetModule is enabled', async () => {
       await withCloseable(TestHttpServers.start, async server => {
         server.byDefault(TestHttpHandlers.respond(200));
         const client = LDClient.initializeInMain(envName, user, {

--- a/src/__tests__/LDClient-useNetModule-test.js
+++ b/src/__tests__/LDClient-useNetModule-test.js
@@ -1,7 +1,13 @@
 import * as LDClient from '../index';
 import * as packageJson from '../../package.json';
 
-import { TestHttpHandlers, TestHttpServer, withCloseable } from 'launchdarkly-js-test-helpers';
+import {
+  TestHttpHandlers,
+  TestHttpServer,
+  TestHttpServers,
+  sleepAsync,
+  withCloseable,
+} from 'launchdarkly-js-test-helpers';
 
 describe('LDClient', () => {
   const envName = 'UNKNOWN_ENVIRONMENT_ID';
@@ -56,23 +62,88 @@ describe('LDClient', () => {
   });
 
   describe('track()', () => {
-    it('should not warn when tracking an arbitrary custom event', async () => {
-      const logger = {
-        debug: jest.fn(),
-        info: jest.fn(),
-        warn: jest.fn(),
-        error: jest.fn(),
-      };
+    it("sends events through Electron's net module", async () => {
+      await withCloseable(TestHttpServers.start, async server => {
+        server.byDefault(TestHttpHandlers.respond(200));
+        const client = LDClient.initializeInMain(envName, user, {
+          bootstrap: {},
+          diagnosticOptOut: true,
+          eventsUrl: server.url,
+          useNetModule: true,
+        });
+        await withCloseable(client, async () => {
+          await client.waitForInitialization();
+
+          client.track('whatever');
+          await client.flush();
+
+          const req = await server.nextRequest();
+          const events = JSON.parse(req.body);
+          expect(events.map(event => event.kind)).toEqual(['identify', 'custom']);
+        });
+      });
+    });
+  });
+
+  describe('configuration', () => {
+    const makeLogger = () => ({
+      debug: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+    });
+
+    it('accepts useNetModule without reporting an unknown option', async () => {
+      const logger = makeLogger();
       const client = LDClient.initializeInMain(envName, user, {
         bootstrap: {},
         sendEvents: false,
-        logger: logger,
+        logger,
         useNetModule: true,
       });
       await withCloseable(client, async () => {
         await client.waitForInitialization();
+        await sleepAsync(10);
 
-        client.track('whatever');
+        expect(logger.warn).not.toHaveBeenCalled();
+        expect(logger.error).not.toHaveBeenCalled();
+      });
+    });
+
+    it('warns once when tlsParams are ignored', async () => {
+      const logger = makeLogger();
+      const client = LDClient.initializeInMain(envName, user, {
+        bootstrap: {},
+        sendEvents: false,
+        logger,
+        tlsParams: { ca: 'custom CA' },
+        useNetModule: true,
+      });
+      await withCloseable(client, async () => {
+        await client.waitForInitialization();
+        await sleepAsync(10);
+
+        expect(logger.warn).toHaveBeenCalledTimes(1);
+        expect(logger.warn).toHaveBeenCalledWith(
+          "The useNetModule option is enabled, so tlsParams will be ignored. Electron's net module delegates TLS " +
+            'configuration to Chromium. Disable useNetModule to use custom TLS parameters.'
+        );
+        expect(logger.error).not.toHaveBeenCalled();
+      });
+    });
+
+    it('does not warn when tlsParams use the Node HTTPS transport', async () => {
+      const logger = makeLogger();
+      const client = LDClient.initializeInMain(envName, user, {
+        bootstrap: {},
+        sendEvents: false,
+        logger,
+        tlsParams: { ca: 'custom CA' },
+      });
+      await withCloseable(client, async () => {
+        await client.waitForInitialization();
+        await sleepAsync(10);
+
         expect(logger.warn).not.toHaveBeenCalled();
         expect(logger.error).not.toHaveBeenCalled();
       });

--- a/src/__tests__/httpRequest-useNetModule-test.js
+++ b/src/__tests__/httpRequest-useNetModule-test.js
@@ -1,0 +1,77 @@
+const EventEmitter = require('events');
+
+describe("httpRequest with Electron's net module", () => {
+  let mockElectronNet;
+  let mockRequest;
+  let newHttpRequest;
+
+  beforeEach(() => {
+    mockRequest = new EventEmitter();
+    mockRequest.setHeader = jest.fn();
+    mockRequest.write = jest.fn();
+    mockRequest.end = jest.fn();
+    mockRequest.abort = jest.fn();
+
+    mockElectronNet = {
+      request: jest.fn(() => mockRequest),
+    };
+    jest.doMock('electron', () => ({ net: mockElectronNet }));
+    newHttpRequest = require('../httpRequest');
+  });
+
+  afterEach(() => {
+    jest.dontMock('electron');
+  });
+
+  it('sends the request and reads the response', async () => {
+    const result = newHttpRequest(
+      'POST',
+      'https://example.com/path',
+      { Authorization: 'token', 'Content-Type': 'application/json' },
+      '{"value":true}',
+      { ca: 'ignored' },
+      true
+    );
+
+    expect(mockElectronNet.request).toHaveBeenCalledWith({
+      method: 'POST',
+      url: 'https://example.com/path',
+    });
+    expect(mockRequest.setHeader.mock.calls).toEqual([
+      ['Authorization', 'token'],
+      ['Content-Type', 'application/json'],
+    ]);
+    expect(mockRequest.write).toHaveBeenCalledWith('{"value":true}');
+    expect(mockRequest.end).toHaveBeenCalledTimes(1);
+
+    const response = new EventEmitter();
+    response.statusCode = 201;
+    response.headers = { 'content-type': 'application/json' };
+    mockRequest.emit('response', response);
+    response.emit('data', '{"ok":');
+    response.emit('data', 'true}');
+    response.emit('end');
+
+    const value = await result.promise;
+    expect(value.status).toEqual(201);
+    expect(value.header('Content-Type')).toEqual('application/json');
+    expect(value.body).toEqual('{"ok":true}');
+  });
+
+  it('rejects the request promise on an error', async () => {
+    const result = newHttpRequest('GET', 'https://example.com', {}, undefined, {}, true);
+    const error = new Error('request failed');
+
+    mockRequest.emit('error', error);
+
+    await expect(result.promise).rejects.toBe(error);
+  });
+
+  it('aborts the Electron request when cancelled', () => {
+    const result = newHttpRequest('GET', 'https://example.com', {}, undefined, {}, true);
+
+    result.cancel();
+
+    expect(mockRequest.abort).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/__tests__/rendererIntegrationTests/renderer-integrationtest.js
+++ b/src/__tests__/rendererIntegrationTests/renderer-integrationtest.js
@@ -70,6 +70,17 @@ describe('full application integration tests', () => {
     await expect(app.getClientFlags(0)).resolves.toEqual(flags);
   });
 
+  doTest("loads flags through Electron's net module", async (fakeLD, app) => {
+    const env = fakeLD.addEnvironment(defaultEnvId);
+    const flags = { flag1: 'value1', flag2: 'value2' };
+    env.addUser(defaultUserKey, flags);
+
+    await app.start({ useNetModule: true });
+
+    await expect(app.getClientUserKey(0)).resolves.toEqual(defaultUserKey);
+    await expect(app.getClientFlags(0)).resolves.toEqual(flags);
+  });
+
   doTest('sends events from renderer client', async (fakeLD, app) => {
     const env = fakeLD.addEnvironment(defaultEnvId);
     env.addUser(defaultUserKey, { flag1: 'value1' });

--- a/src/__tests__/rendererIntegrationTests/testAppClient.js
+++ b/src/__tests__/rendererIntegrationTests/testAppClient.js
@@ -16,6 +16,7 @@ const spectron = require('spectron');
 //   testName: will be displayed in the window
 //   userKey: clients will be initialized with this user
 //   streaming: true to enable streaming
+//   useNetModule: true to use Electron's net module
 
 function testAppClient(fakeLD, baseOptions) {
   let app;
@@ -52,6 +53,7 @@ function testAppClient(fakeLD, baseOptions) {
     args.push('-u', options.userKey);
     args.push('-e', envs.join(','));
     options.streaming && args.push('--streaming');
+    options.useNetModule && args.push('--useNetModule');
 
     app = new spectron.Application({
       path: electron,

--- a/src/__tests__/rendererIntegrationTests/testAppMain.js
+++ b/src/__tests__/rendererIntegrationTests/testAppMain.js
@@ -10,6 +10,7 @@ const ldOptions = {
   logger: ldElectron.createConsoleLogger('debug'),
   streaming: args.streaming,
   useReport: true,
+  useNetModule: args.useNetModule === true,
 };
 
 const testConfig = {

--- a/src/electronPlatform.js
+++ b/src/electronPlatform.js
@@ -9,7 +9,8 @@ function makeElectronPlatform(options) {
 
   const ret = {};
 
-  ret.httpRequest = (method, url, headers, body) => newHttpRequest(method, url, headers, body, tlsParams);
+  ret.httpRequest = (method, url, headers, body) =>
+    newHttpRequest(method, url, headers, body, tlsParams, options && options.useNetModule);
 
   ret.httpAllowsPost = () => true;
 

--- a/src/electronPlatform.js
+++ b/src/electronPlatform.js
@@ -4,13 +4,20 @@ const { EventSource } = require('launchdarkly-eventsource');
 const newHttpRequest = require('./httpRequest');
 const packageJson = require('../package.json');
 
-function makeElectronPlatform(options) {
+function makeElectronPlatform(options, logger) {
   const tlsParams = filterTlsParams(options && options.tlsParams);
+  const useNetModule = options && options.useNetModule;
+
+  if (useNetModule && Object.keys(tlsParams).length > 0 && logger && typeof logger.warn === 'function') {
+    logger.warn(
+      "The useNetModule option is enabled, so tlsParams will be ignored. Electron's net module delegates TLS " +
+        'configuration to Chromium. Disable useNetModule to use custom TLS parameters.'
+    );
+  }
 
   const ret = {};
 
-  ret.httpRequest = (method, url, headers, body) =>
-    newHttpRequest(method, url, headers, body, tlsParams, options && options.useNetModule);
+  ret.httpRequest = (method, url, headers, body) => newHttpRequest(method, url, headers, body, tlsParams, useNetModule);
 
   ret.httpAllowsPost = () => true;
 

--- a/src/httpRequest.js
+++ b/src/httpRequest.js
@@ -5,19 +5,20 @@ const http = require('http');
 const https = require('https');
 const url = require('url');
 
-function newHttpRequest(method, requestUrl, headers, body, tlsParams) {
+let electronNet;
+try {
+  electronNet = require('electron').net;
+} catch (_) {
+  // Not in Electron or outside main process
+}
+
+function newHttpRequest(method, requestUrl, headers, body, tlsParams, useNetModule) {
   const urlParams = url.parse(requestUrl);
   const isHttps = urlParams.protocol === 'https:';
 
-  const requestParams = Object.assign({}, isHttps ? tlsParams : {}, urlParams, {
-    method: method,
-    headers: headers,
-    body: body,
-  });
-
   let request;
   const p = new Promise((resolve, reject) => {
-    request = (isHttps ? https : http).request(requestParams, res => {
+    const onResponse = res => {
       let resBody = '';
       res.on('data', chunk => {
         resBody += chunk;
@@ -29,12 +30,31 @@ function newHttpRequest(method, requestUrl, headers, body, tlsParams) {
           body: resBody,
         });
       });
-    });
+    };
+
+    if (useNetModule && electronNet) {
+      request = electronNet.request({ method, url: requestUrl });
+
+      for (const [key, value] of Object.entries(headers)) {
+        request.setHeader(key, value);
+      }
+
+      request.on('response', onResponse);
+    } else {
+      const requestParams = Object.assign({}, isHttps ? tlsParams : {}, urlParams, {
+        method: method,
+        headers: headers,
+        body: body,
+      });
+
+      request = (isHttps ? https : http).request(requestParams, onResponse);
+    }
 
     request.on('error', reject);
     if (body) {
       request.write(body);
     }
+
     request.end();
   });
 

--- a/src/index.js
+++ b/src/index.js
@@ -11,10 +11,14 @@ const packageJson = require('../package.json');
 // initializeRenderer).
 function initializeInMain(env, user, options = {}) {
   // Pass our platform object to the common code to create the Electron version of the client
-  const platform = electronPlatform(options);
-  const extraOptionDefs = {};
+  const logger = options.logger || createDefaultLogger();
+  const platform = electronPlatform(options, logger);
+  const extraOptionDefs = {
+    tlsParams: { type: 'object' },
+    useNetModule: { default: false },
+  };
   if (!options.logger) {
-    extraOptionDefs.logger = { default: createDefaultLogger() };
+    extraOptionDefs.logger = { default: logger };
   }
   const clientVars = common.initialize(env, user, options, platform, extraOptionDefs);
   const client = clientVars.client;

--- a/test-types.ts
+++ b/test-types.ts
@@ -13,6 +13,8 @@ var allOptions: ld.LDOptions = {
   streamUrl: '',
   streaming: true,
   useReport: true,
+  useNetModule: true,
+  tlsParams: { rejectUnauthorized: false },
   sendLDHeaders: true,
   evaluationReasons: true,
   sendEvents: true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,8 @@
     "lib": [
       "es6",
       "dom"
-    ]
+    ],
+    "types": []
   },
   "files": [
     "typings.d.ts",

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -60,6 +60,7 @@ declare module 'launchdarkly-electron-client-sdk' {
    * Initialization options for the LaunchDarkly Electron SDK.
    */
   export interface LDOptions extends LDOptionsBase {
+    useNetModule?: boolean;
   }
 
   /**

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -60,6 +60,25 @@ declare module 'launchdarkly-electron-client-sdk' {
    * Initialization options for the LaunchDarkly Electron SDK.
    */
   export interface LDOptions extends LDOptionsBase {
+    /**
+     * TLS configuration parameters supported by Node's `https.request()`.
+     *
+     * The SDK passes these parameters to Node's `https.request()` when `useNetModule` is false. Electron's
+     * `net` module does not accept per-request TLS parameters, so the SDK ignores this option and logs a
+     * warning when both options are set.
+     */
+    tlsParams?: object;
+
+    /**
+     * Whether to use Electron's `net` module for polling, analytics event, and diagnostic requests made
+     * by the main-process client. This allows those requests to use Chromium's networking stack and proxy
+     * configuration. It does not change the transport used for streaming connections. Since Electron only
+     * makes the `net` API available after the app is ready, call `initializeInMain` after Electron's `ready`
+     * event when enabling this option.
+     *
+     * When this option is true, Chromium handles TLS configuration and the SDK does not apply `tlsParams`.
+     * The default is false.
+     */
     useNetModule?: boolean;
   }
 


### PR DESCRIPTION
**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/master/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

**Related issues**

/

**Describe the solution you've provided**

- Added a new argument called `useNetModule` that will use [Electron's net module](https://www.electronjs.org/docs/latest/api/net) instead of request
- Added an empty array to `types` property in `tsconfig.json` to prevent @types libraries from `node_modules` from being checked when running `npm run check-typescript`

**Describe alternatives you've considered**

/

**Additional context**

/

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Overview**
> Adds an opt-in **`useNetModule`** option on `initializeInMain` so polling, analytics, and diagnostic requests use Electron’s `net` module (Chromium networking and system proxies). Streaming still uses EventSource.
> 
> When the option is on, custom **`tlsParams`** are not applied and a warning is logged if both are set. Callers must initialize after the app `ready` event. Types, README, changelog, and tests cover the new path and the TLS warning. `tsconfig` now sets `"types": []` so TypeScript checks ignore extra `@types` packages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 09331695a9e9b78d0be8ac74c641ce4ef8f27dc9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->